### PR TITLE
Fix code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/backend/src/helpers/utils.ts
+++ b/backend/src/helpers/utils.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'stream';
 import https from "node:https";
+import { URL } from 'url';
 
 export const isUndefined = (item: any): boolean => {
     return typeof(item) === "undefined"
@@ -9,7 +10,21 @@ export const unixTimestamp = () => {
     return Math.floor(Date.now() / 1000)
 }
 
+const isValidUrl = (url: string, allowedDomains: string[]): boolean => {
+    try {
+        const parsedUrl = new URL(url);
+        return allowedDomains.includes(parsedUrl.hostname);
+    } catch (err) {
+        return false;
+    }
+}
+
 export const createUrlReadStream = (url: string): Readable => {
+    const allowedDomains = ['trusted-domain.com', 'another-trusted-domain.com'];
+    if (!isValidUrl(url, allowedDomains)) {
+        throw new Error('Invalid URL');
+    }
+
     const readable = new Readable({
       read() {}, // No-op
     })

--- a/backend/src/helpers/utils.ts
+++ b/backend/src/helpers/utils.ts
@@ -20,7 +20,7 @@ const isValidUrl = (url: string, allowedDomains: string[]): boolean => {
 }
 
 export const createUrlReadStream = (url: string): Readable => {
-    const allowedDomains = ['trusted-domain.com', 'another-trusted-domain.com'];
+    const allowedDomains = ['cdn.openai.com', 'openaiusercontent.com', 'files.oaiusercontent.com', 'picsum.photos'];
     if (!isValidUrl(url, allowedDomains)) {
         throw new Error('Invalid URL');
     }


### PR DESCRIPTION
Fixes [https://github.com/CheriseCodes/ai-flash-cards/security/code-scanning/1](https://github.com/CheriseCodes/ai-flash-cards/security/code-scanning/1)

To fix the problem, we need to ensure that the `url` parameter in the `createUrlReadStream` function is validated before being used in the `https.get` request. One way to achieve this is by using an allow-list of trusted domains and ensuring that the `url` parameter matches one of these domains. This will prevent attackers from using arbitrary URLs in the request.

We will:
1. Add a function to validate the URL against an allow-list of trusted domains.
2. Modify the `createUrlReadStream` function to use this validation function before making the `https.get` request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
